### PR TITLE
fix: make iter consume value

### DIFF
--- a/src/checked_num.rs
+++ b/src/checked_num.rs
@@ -117,7 +117,7 @@ impl<T: CheckedNumTraits> Iterator for CheckedNum<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.as_option()
+        self.0.take()
     }
 }
 


### PR DESCRIPTION
The old implementation just copies the inner value when calling `iter.next()`. Now it is actually moved out.

@luk-esc co-authored
